### PR TITLE
Fix multiplayer game loop

### DIFF
--- a/main.js
+++ b/main.js
@@ -562,6 +562,11 @@ function startCountdown(seconds) {
     let count = seconds;
     countdownText.textContent = count;
 
+    // Ensure the game loop is running for multiplayer countdown
+    if (gameMode === "multi") {
+        requestAnimationFrame(gameLoop);
+    }
+
     const interval = setInterval(() => {
         count--;
         if (count > 0) {


### PR DESCRIPTION
## Summary
- ensure the game loop starts when a multiplayer match countdown begins

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687898aa26008325bed27e728c923d71